### PR TITLE
added more rendering logic so that we better optimize space of visualizing panels

### DIFF
--- a/grafana/provisioning/dashboards/wrapper.py
+++ b/grafana/provisioning/dashboards/wrapper.py
@@ -131,7 +131,6 @@ class SceGrafanalibWrapper:
                     datasource=PROMETHEUS_DATASOURCE_NAME,
                 )
             )
-
         panel = panel_type_enum.value(
             title=title,
             targets=targets,
@@ -161,21 +160,16 @@ class SceGrafanalibWrapper:
             panel.format = unit
         row_or_panel = self.rows[-1].panels if self.rows else self.panels
         row_or_panel.append(panel)
-        
-        # Update position for next panel
         self.current_x += self.panel_width
         if self.current_x >= self.MAX_WIDTH:
-            # Move to next row
-            self.current_x = 0
             self.current_y += self.panel_height
+            self.current_x = 0
 
     def Render(self):
-        dashboard = Dashboard(
+        return Dashboard(
             title=self.title,
             rows=self.rows,
             panels=self.panels,
             timezone="browser",
             templating=Templating(list=self.templates),
-        )
-        
-        return dashboard.auto_panel_ids()
+        ).auto_panel_ids()

--- a/grafana/provisioning/dashboards/wrapper.py
+++ b/grafana/provisioning/dashboards/wrapper.py
@@ -132,15 +132,12 @@ class SceGrafanalibWrapper:
                 )
             )
 
-        # Calculate panel width dynamically for 50% width layout
-        panel_width = self.MAX_WIDTH // 2
-        
         panel = panel_type_enum.value(
             title=title,
             targets=targets,
             gridPos=GridPos(
                 h=self.panel_height,
-                w=panel_width,
+                w=self.panel_width,
                 x=self.current_x,
                 y=self.current_y,
             ),
@@ -166,7 +163,7 @@ class SceGrafanalibWrapper:
         row_or_panel.append(panel)
         
         # Update position for next panel
-        self.current_x += panel_width
+        self.current_x += self.panel_width
         if self.current_x >= self.MAX_WIDTH:
             # Move to next row
             self.current_x = 0
@@ -187,7 +184,5 @@ class SceGrafanalibWrapper:
             templating=Templating(list=self.templates),
         )
         
-        # Store original row structure for future features
-        dashboard._original_rows = self.rows
         
         return dashboard.auto_panel_ids()

--- a/grafana/provisioning/dashboards/wrapper.py
+++ b/grafana/provisioning/dashboards/wrapper.py
@@ -170,19 +170,12 @@ class SceGrafanalibWrapper:
             self.current_y += self.panel_height
 
     def Render(self):
-        # Collect all panels from rows
-        all_panels = []
-        for row in self.rows:
-            all_panels.extend(row.panels)
-        all_panels.extend(self.panels)
-        
-        # Create dashboard - panels already have correct positioning from AddPanel
         dashboard = Dashboard(
             title=self.title,
-            panels=all_panels,
+            rows=self.rows,
+            panels=self.panels,
             timezone="browser",
             templating=Templating(list=self.templates),
         )
-        
         
         return dashboard.auto_panel_ids()

--- a/grafana/provisioning/dashboards/wrapper.py
+++ b/grafana/provisioning/dashboards/wrapper.py
@@ -166,10 +166,42 @@ class SceGrafanalibWrapper:
             self.current_x = 0
 
     def Render(self):
-        return Dashboard(
+        # Collect all panels from rows
+        all_panels = []
+        for row in self.rows:
+            all_panels.extend(row.panels)
+        all_panels.extend(self.panels)
+        
+        
+        panel_width = self.MAX_WIDTH // 2  
+        current_x = 0
+        current_y = 0
+        
+        for i, panel in enumerate(all_panels):
+            # Update panel to have 50% width and correct position
+            panel.gridPos = GridPos(
+                h=self.panel_height,
+                w=panel_width,
+                x=current_x,
+                y=current_y,
+            )
+            
+            # Move to next position
+            current_x += panel_width
+            if current_x >= self.MAX_WIDTH:
+                # Move to next row
+                current_x = 0
+                current_y += self.panel_height
+        
+        # Create dashboard with rearranged panels
+        dashboard = Dashboard(
             title=self.title,
-            rows=self.rows,
-            panels=self.panels,
+            panels=all_panels,  # Use the rearranged panels
             timezone="browser",
             templating=Templating(list=self.templates),
-        ).auto_panel_ids()
+        )
+        
+        # Store original row structure for future features
+        dashboard._original_rows = self.rows
+        
+        return dashboard.auto_panel_ids()

--- a/grafana/provisioning/dashboards/wrapper.py
+++ b/grafana/provisioning/dashboards/wrapper.py
@@ -54,9 +54,6 @@ class SceGrafanalibWrapper:
         self.title = title
         self.current_x = 0
         self.current_y = 0
-        # Global position tracking for cross-row panel positioning
-        self.global_current_x = 0
-        self.global_current_y = 0
         self.panel_width = min(panel_width, self.MAX_WIDTH)
         self.panel_height = panel_height
         self.templates = []
@@ -144,8 +141,8 @@ class SceGrafanalibWrapper:
             gridPos=GridPos(
                 h=self.panel_height,
                 w=panel_width,
-                x=self.global_current_x,
-                y=self.global_current_y,
+                x=self.current_x,
+                y=self.current_y,
             ),
         )
         if isinstance(panel, TimeSeries):
@@ -168,12 +165,12 @@ class SceGrafanalibWrapper:
         row_or_panel = self.rows[-1].panels if self.rows else self.panels
         row_or_panel.append(panel)
         
-        # Update global position tracking for cross-row positioning
-        self.global_current_x += panel_width
-        if self.global_current_x >= self.MAX_WIDTH:
+        # Update position for next panel
+        self.current_x += panel_width
+        if self.current_x >= self.MAX_WIDTH:
             # Move to next row
-            self.global_current_x = 0
-            self.global_current_y += self.panel_height
+            self.current_x = 0
+            self.current_y += self.panel_height
 
     def Render(self):
         # Collect all panels from rows


### PR DESCRIPTION
Before the problem was that rows would not be inclusive, so for example if a row only had 1 panel, it would take up the whole width. Instead we want that rows panel to be generous and share space with the next rows panel.

Here is a before:
<img width="1440" height="793" alt="Screenshot 2025-07-07 at 1 04 39 AM" src="https://github.com/user-attachments/assets/39f52f0d-9ab8-4ce2-9776-110a2e1cc17e" />
The top panel (Container Uptime) is taking up too much space and not sharing it. 

Changed the logic so we update current_x by adding the panel width. we only change current_x and current_y if current_x >= maxWidth. 

After: 
<img width="1440" height="793" alt="Screenshot 2025-07-12 at 1 55 55 PM" src="https://github.com/user-attachments/assets/5e6bc04d-3b54-491a-afbf-37e65efaf691" />
