### PR TITLE
Scetv dashboard HTTP Request Panel fix

### DIFF
--- a/grafana/provisioning/dashboards/scetv.dashboard.py
+++ b/grafana/provisioning/dashboards/scetv.dashboard.py
@@ -30,7 +30,17 @@ wrapper.AddPanel(
             expression='http_request_count_total{endpoint!=\"/metrics\"}',
             legend='{{endpoint}}'
     )],
-    panel_type_enum=PanelType.BARGAUGE
+    unit=NUMBER_FORMAT,
+    panel_type_enum=PanelType.BARGAUGE,
+    extraJson={
+        'options': {
+            'fieldOptions': {
+                "calcs": [
+                    "lastNotNull"
+                ],
+            },
+        }
+    }
 )
 
 wrapper.AddPanel(


### PR DESCRIPTION
<img width="1720" height="555" alt="{E3A367B7-1A82-4063-A706-D1D2F13C7643}" src="https://github.com/user-attachments/assets/1370a36b-06ec-4e06-8578-12275c8b0bc5" />

ensures the reduce calculation uses "lastNotNull"

this fixes issue where the number of HTTP Requests showed a decimal number