### PR TITLE
Add CICD Grafana dashboard

### DIFF
--- a/grafana/provisioning/dashboards/cicd.dashboard.py
+++ b/grafana/provisioning/dashboards/cicd.dashboard.py
@@ -1,0 +1,76 @@
+from grafanalib.formatunits import NUMBER_FORMAT, SECONDS
+
+from wrapper import SceGrafanalibWrapper, ExpressionAndLegendPair, PanelType
+
+wrapper = SceGrafanalibWrapper(title="CICD")
+
+wrapper.AddPanel(
+    title="CICD Deployments",
+    queries=[
+        ExpressionAndLegendPair(
+            'cicd_deployments_total',
+            "{{repo}} {{branch}}",
+        )
+    ],
+    dydt=True,
+    unit=NUMBER_FORMAT,
+)
+
+wrapper.AddPanel(
+    title="CICD Deployment Failures",
+    queries=[
+        ExpressionAndLegendPair(
+            'cicd_deployment_failures_total',
+            "{{repo}} {{branch}}",
+        )
+    ],
+    dydt=True,
+    unit=NUMBER_FORMAT,
+)
+
+wrapper.AddPanel(
+    title="CICD Restarts",
+    queries=[
+        ExpressionAndLegendPair(
+            'cicd_restarts_total',
+            "{{host}}",
+        )
+    ],
+    dydt=True,
+    unit=NUMBER_FORMAT,
+)
+
+wrapper.AddPanel(
+    title="CICD Deployment Duration",
+    queries=[
+        ExpressionAndLegendPair(
+            'cicd_deployment_duration_seconds',
+            "{{repo}} {{branch}}",
+        )
+    ],
+    unit=SECONDS,
+)
+
+wrapper.AddPanel(
+    title="CICD Server Uptime",
+    queries=[
+        ExpressionAndLegendPair(
+            'time() - process_start_time_seconds{job="sce-cicd"}',
+        )
+    ],
+    unit=SECONDS,
+)
+
+wrapper.AddPanel(
+    title="CICD Server Up",
+    queries=[
+        ExpressionAndLegendPair(
+            'up{job="sce-cicd"}',
+            "{{instance}}",
+        )
+    ],
+    panel_type_enum=PanelType.STAT,
+    unit=NUMBER_FORMAT,
+)
+
+dashboard = wrapper.Render()


### PR DESCRIPTION
Adds a new CICD Grafana dashboard with panels for deployments, failures, restarts, deployment duration, server uptime, and server up status.