### PR TITLE
Add Prometheus Pushgateway service

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -64,7 +64,7 @@ services:
   pushgateway:
     image: prom/pushgateway:latest
     restart: unless-stopped
-    ports: 
+    ports:
       - 9091:9091
 
 volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -61,6 +61,11 @@ services:
       - '--path.rootfs=/host'
     pid: host
     restart: unless-stopped
+  pushgateway:
+    image: prom/pushgateway:latest
+    restart: unless-stopped
+    ports: 
+      - 9091:9091
 
 volumes:
   alertmanager-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,9 @@ services:
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
       - portainer_data:/data
+  pushgateway:
+    image: prom/pushgateway:latest
+    restart: unless-stopped
 
 volumes:
   alertmanager-data:

--- a/prometheus/prometheus.federate.yml
+++ b/prometheus/prometheus.federate.yml
@@ -13,6 +13,9 @@ scrape_configs:
       - targets: 
         - prometheus-clark-sshtunnel:9090
         - prometheus-poweredge:9090
+  - job_name: 'pushgateway'
+    static_configs:
+      - targets: ['pushgateway:9091']
 
 alerting:
   alertmanagers:

--- a/pushgateway-nginx-test/Dockerfile
+++ b/pushgateway-nginx-test/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir prometheus-client
+
+COPY push_metrics.py .
+
+CMD ["python", "push_metrics.py"]

--- a/pushgateway-nginx-test/docker-compose.yml
+++ b/pushgateway-nginx-test/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  pushgateway:
+    image: prom/pushgateway:latest
+    command:
+      - '--web.external-url=http://localhost:80/pushgateway/'
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - '80:80'
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - pushgateway
+
+  pusher:
+    build: .
+    depends_on:
+      - nginx

--- a/pushgateway-nginx-test/nginx.conf
+++ b/pushgateway-nginx-test/nginx.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+
+    location = /pushgateway {
+        return 301 /pushgateway/;
+    }
+
+    location /pushgateway/ {
+        proxy_pass http://pushgateway:9091;
+    }
+}

--- a/pushgateway-nginx-test/push_metrics.py
+++ b/pushgateway-nginx-test/push_metrics.py
@@ -1,0 +1,18 @@
+from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+
+registry = CollectorRegistry()
+
+metric = Gauge( 
+    "nginx_pushgateway_test",
+    "Metric sent through the Nginx proxy",
+    registry=registry,
+)
+metric.set(50)
+
+push_to_gateway(
+    "http://nginx/pushgateway",
+    job="nginx_proxy_test",
+    registry=registry,
+)
+
+print("successfully pushed metric")


### PR DESCRIPTION
Add a Pushgateway container to the production and development Docker Compose configurations
Expose Pushgateway on port 9091 in the development configuration
Configure federated Prometheus to scrape Pushgateway metrics